### PR TITLE
0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - @tideline3d
 - [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
+- [Calanish](https://github.com/calanish)
 
 ### Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ or manually using this URL:
 
     https://github.com/jneilliii/OctoPrint-ConsolidateTempControl/archive/master.zip
 
+## Most recent changelog
+
+**[0.1.8](https://github.com/jneilliii/OctoPrint-ConsolidateTempControl/releases/tag/0.1.8)** (11/22/2020)
+
+**Added**
+
+* resolution threshold option for horizontal mode to switch to vertical mode automatically
+* release channels for OctoPrint 1.5.0+ for future rc testing, similar to OctoPrint as described [here](https://community.octoprint.org/t/how-to-use-the-release-channels-to-help-test-release-candidates/402)
+
+**Updated**
+
+* knockout sortable library for OctoPrint 1.5.0 compatibility
+
+**Fixed**
+
+* conflicts with Themeify and DragonOrder
+
+### [All releases](https://github.com/jneilliii/OctoPrint-ConsolidateTempControl/releases)
+
 ## Get Help
 
 If you experience issues with this plugin or need assistance please use the issue tracker by clicking issues above.

--- a/octoprint_consolidate_temp_control/__init__.py
+++ b/octoprint_consolidate_temp_control/__init__.py
@@ -20,7 +20,7 @@ class ConsolidateTempControlPlugin(octoprint.plugin.TemplatePlugin,
 
 	##-- AssetPlugin mixin
 	def get_assets(self):
-		return dict(js=["js/jquery-ui.min.js","js/knockout-sortable.js","js/consolidate_temp_control.js"])
+		return dict(js=["js/jquery-ui.min.js","js/knockout-sortable.1.2.0.js","js/consolidate_temp_control.js"])
 
 	##~~ Softwareupdate hook
 	def update_hook(self):
@@ -34,6 +34,16 @@ class ConsolidateTempControlPlugin(octoprint.plugin.TemplatePlugin,
 				user="jneilliii",
 				repo="OctoPrint-ConsolidateTempControl",
 				current=self._plugin_version,
+				stable_branch=dict(
+					name="Stable", branch="master", comittish=["master"]
+				),
+				prerelease_branches=[
+					dict(
+						name="Release Candidate",
+						branch="rc",
+						comittish=["rc", "master"],
+					)
+				],
 
 				# update method: pip
 				pip="https://github.com/jneilliii/OctoPrint-ConsolidateTempControl/archive/{target_version}.zip"

--- a/octoprint_consolidate_temp_control/__init__.py
+++ b/octoprint_consolidate_temp_control/__init__.py
@@ -9,7 +9,7 @@ class ConsolidateTempControlPlugin(octoprint.plugin.TemplatePlugin,
 
 	##-- Settings mixin
 	def get_settings_defaults(self):
-		return dict(tab_order=[dict(name="Temperature",selector="#temp"),dict(name="Control",selector="#control")], layout="horizontal", resize_navbar=True)
+		return dict(tab_order=[dict(name="Temperature",selector="#temp"),dict(name="Control",selector="#control")], layout="horizontal", resize_navbar=True, resolution_threshold=0)
 
 	##-- Template mixin
 	def get_template_configs(self):

--- a/octoprint_consolidate_temp_control/static/js/consolidate_temp_control.js
+++ b/octoprint_consolidate_temp_control/static/js/consolidate_temp_control.js
@@ -28,7 +28,7 @@ $(function() {
 			});
 			$('#temp_link, #control_link').remove();
 
-			if(self.settings.settings.plugins.consolidate_temp_control.layout() == 'horizontal'){
+			if(self.settings.settings.plugins.consolidate_temp_control.layout() == 'horizontal' && (screen.width >= parseInt(self.settings.settings.plugins.consolidate_temp_control.resolution_threshold(), 10) && self.settings.settings.plugins.consolidate_temp_control.resolution_threshold() >= 0)){
 				// page container adjustments
 				$('div.page-container').css({'min-width':'1900px'});
 
@@ -44,7 +44,9 @@ $(function() {
 
 				// sidebar adjustments
 				if (!self.dragonorder) {
-					$('div.container.octoprint-container > div.row > div.accordion.span4').removeClass('span4').addClass('span2');
+					if($('div#settings_plugin_themeify').length == 0){
+						$('div.container.octoprint-container > div.row > div.accordion.span4').removeClass('span4').addClass('span2');
+					}
 					$('#files div.row-fluid.upload-buttons > span.btn.btn-primary.fileinput-button.span6:nth-child(2) > span').text('Upload SD');
 				}
 
@@ -129,7 +131,7 @@ $(function() {
 					self.temperatureViewModel.updatePlot();
 				}
 				self.temperatureViewModel.onAfterTabChange("#temp", previous);
-			} 
+			}
 		}
 	}
 

--- a/octoprint_consolidate_temp_control/static/js/knockout-sortable.1.2.0.js
+++ b/octoprint_consolidate_temp_control/static/js/knockout-sortable.1.2.0.js
@@ -1,0 +1,490 @@
+// knockout-sortable 1.2.0 | (c) 2019 Ryan Niemeyer |  http://www.opensource.org/licenses/mit-license
+;(function(factory) {
+    if (typeof define === "function" && define.amd) {
+        // AMD anonymous module
+        define(["knockout", "jquery", "jquery-ui/ui/widgets/sortable", "jquery-ui/ui/widgets/draggable", "jquery-ui/ui/widgets/droppable"], factory);
+    } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
+        // CommonJS module
+        var ko = require("knockout"),
+            jQuery = require("jquery");
+        require("jquery-ui/ui/widgets/sortable");
+        require("jquery-ui/ui/widgets/draggable");
+        require("jquery-ui/ui/widgets/droppable");
+        factory(ko, jQuery);
+    } else {
+        // No module loader (plain <script> tag) - put directly in global namespace
+        factory(window.ko, window.jQuery);
+    }
+})(function(ko, $) {
+    var ITEMKEY = "ko_sortItem",
+        INDEXKEY = "ko_sourceIndex",
+        LISTKEY = "ko_sortList",
+        PARENTKEY = "ko_parentList",
+        DRAGKEY = "ko_dragItem",
+        unwrap = ko.utils.unwrapObservable,
+        dataGet = ko.utils.domData.get,
+        dataSet = ko.utils.domData.set,
+        version = $.ui && $.ui.version,
+        //1.8.24 included a fix for how events were triggered in nested sortables. indexOf checks will fail if version starts with that value (0 vs. -1)
+        hasNestedSortableFix = version && version.indexOf("1.6.") && version.indexOf("1.7.") && (version.indexOf("1.8.") || version === "1.8.24");
+
+    //internal afterRender that adds meta-data to children
+    var addMetaDataAfterRender = function(elements, data) {
+        ko.utils.arrayForEach(elements, function(element) {
+            if (element.nodeType === 1) {
+                dataSet(element, ITEMKEY, data);
+                dataSet(element, PARENTKEY, dataGet(element.parentNode, LISTKEY));
+            }
+        });
+    };
+
+    //prepare the proper options for the template binding
+    var prepareTemplateOptions = function(valueAccessor, dataName) {
+        var result = {},
+            options = {},
+            actualAfterRender;
+
+        //build our options to pass to the template engine
+        if (ko.utils.peekObservable(valueAccessor()).data) {
+            options = unwrap(valueAccessor() || {});
+            result[dataName] = options.data;
+            if (options.hasOwnProperty("template")) {
+                result.name = options.template;
+            }
+        } else {
+            result[dataName] = valueAccessor();
+        }
+
+        ko.utils.arrayForEach(["afterAdd", "afterRender", "as", "beforeRemove", "includeDestroyed", "templateEngine", "templateOptions", "nodes"], function (option) {
+            if (options.hasOwnProperty(option)) {
+                result[option] = options[option];
+            } else if (ko.bindingHandlers.sortable.hasOwnProperty(option)) {
+                result[option] = ko.bindingHandlers.sortable[option];
+            }
+        });
+
+        //use an afterRender function to add meta-data
+        if (dataName === "foreach") {
+            if (result.afterRender) {
+                //wrap the existing function, if it was passed
+                actualAfterRender = result.afterRender;
+                result.afterRender = function(element, data) {
+                    addMetaDataAfterRender.call(data, element, data);
+                    actualAfterRender.call(data, element, data);
+                };
+            } else {
+                result.afterRender = addMetaDataAfterRender;
+            }
+        }
+
+        //return options to pass to the template binding
+        return result;
+    };
+
+    var updateIndexFromDestroyedItems = function(index, items) {
+        var unwrapped = unwrap(items);
+
+        if (unwrapped) {
+            for (var i = 0; i <= index; i++) {
+                //add one for every destroyed item we find before the targetIndex in the target array
+                if (unwrapped[i] && unwrap(unwrapped[i]._destroy)) {
+                    index++;
+                }
+            }
+        }
+
+        return index;
+    };
+
+    //remove problematic leading/trailing whitespace from templates
+    var stripTemplateWhitespace = function(element, name) {
+        var templateSource,
+            templateElement;
+
+        //process named templates
+        if (name) {
+            templateElement = document.getElementById(name);
+            if (templateElement) {
+                templateSource = new ko.templateSources.domElement(templateElement);
+                templateSource.text($.trim(templateSource.text()));
+            }
+        }
+        else {
+            //remove leading/trailing non-elements from anonymous templates
+            $(element).contents().each(function() {
+                if (this && this.nodeType !== 1) {
+                    element.removeChild(this);
+                }
+            });
+        }
+    };
+
+    //connect items with observableArrays
+    ko.bindingHandlers.sortable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var $element = $(element),
+                value = unwrap(valueAccessor()) || {},
+                templateOptions = prepareTemplateOptions(valueAccessor, "foreach"),
+                sortable = {},
+                startActual, updateActual;
+
+            stripTemplateWhitespace(element, templateOptions.name);
+
+            //build a new object that has the global options with overrides from the binding
+            $.extend(true, sortable, ko.bindingHandlers.sortable);
+            if (value.options && sortable.options) {
+                ko.utils.extend(sortable.options, value.options);
+                delete value.options;
+            }
+            ko.utils.extend(sortable, value);
+
+            //if allowDrop is an observable or a function, then execute it in a computed observable
+            if (sortable.connectClass && (ko.isObservable(sortable.allowDrop) || typeof sortable.allowDrop == "function")) {
+                ko.computed({
+                    read: function() {
+                        var value = unwrap(sortable.allowDrop),
+                            shouldAdd = typeof value == "function" ? value.call(this, templateOptions.foreach) : value;
+                        ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, shouldAdd);
+                    },
+                    disposeWhenNodeIsRemoved: element
+                }, this);
+            } else {
+                ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, sortable.allowDrop);
+            }
+
+            //wrap the template binding
+            ko.bindingHandlers.template.init(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+
+            //keep a reference to start/update functions that might have been passed in
+            startActual = sortable.options.start;
+            updateActual = sortable.options.update;
+
+            //ensure draggable table row cells maintain their width while dragging (unless a helper is provided)
+            if ( !sortable.options.helper ) {
+                sortable.options.helper = function(e, ui) {
+                    if (ui.is("tr")) {
+                        ui.children().each(function() {
+                            $(this).width($(this).width());
+                        });
+                    }
+                    return ui;
+                };
+            }
+
+            //initialize sortable binding after template binding has rendered in update function
+            var createTimeout = setTimeout(function() {
+                var dragItem;
+                var originalReceive = sortable.options.receive;
+
+                $element.sortable(ko.utils.extend(sortable.options, {
+                    start: function(event, ui) {
+                        //track original index
+                        var el = ui.item[0];
+                        dataSet(el, INDEXKEY, ko.utils.arrayIndexOf(ui.item.parent().children(), el));
+
+                        //make sure that fields have a chance to update model
+                        ui.item.find("input:focus").change();
+                        if (startActual) {
+                            startActual.apply(this, arguments);
+                        }
+                    },
+                    receive: function(event, ui) {
+                        //optionally apply an existing receive handler
+                        if (typeof originalReceive === "function") {
+                            originalReceive.call(this, event, ui);
+                        }
+
+                        dragItem = dataGet(ui.item[0], DRAGKEY);
+                        if (dragItem) {
+                            //copy the model item, if a clone option is provided
+                            if (dragItem.clone) {
+                                dragItem = dragItem.clone();
+                            }
+
+                            //configure a handler to potentially manipulate item before drop
+                            if (sortable.dragged) {
+                                dragItem = sortable.dragged.call(this, dragItem, event, ui) || dragItem;
+                            }
+                        }
+                    },
+                    update: function(event, ui) {
+                        var sourceParent, targetParent, sourceIndex, targetIndex, arg,
+                            el = ui.item[0],
+                            parentEl = ui.item.parent()[0],
+                            item = dataGet(el, ITEMKEY) || dragItem;
+
+                        if (!item) {
+                            $(el).remove();
+                        }
+                        dragItem = null;
+
+                        //make sure that moves only run once, as update fires on multiple containers
+                        if (item && (this === parentEl) || (!hasNestedSortableFix && $.contains(this, parentEl))) {
+                            //identify parents
+                            sourceParent = dataGet(el, PARENTKEY);
+                            sourceIndex = dataGet(el, INDEXKEY);
+                            targetParent = dataGet(el.parentNode, LISTKEY);
+                            targetIndex = ko.utils.arrayIndexOf(ui.item.parent().children(), el);
+
+                            //take destroyed items into consideration
+                            if (!templateOptions.includeDestroyed) {
+                                sourceIndex = updateIndexFromDestroyedItems(sourceIndex, sourceParent);
+                                targetIndex = updateIndexFromDestroyedItems(targetIndex, targetParent);
+                            }
+
+                            //build up args for the callbacks
+                            if (sortable.beforeMove || sortable.afterMove) {
+                                arg = {
+                                    item: item,
+                                    sourceParent: sourceParent,
+                                    sourceParentNode: sourceParent && ui.sender || el.parentNode,
+                                    sourceIndex: sourceIndex,
+                                    targetParent: targetParent,
+                                    targetIndex: targetIndex,
+                                    cancelDrop: false
+                                };
+
+                                //execute the configured callback prior to actually moving items
+                                if (sortable.beforeMove) {
+                                    sortable.beforeMove.call(this, arg, event, ui);
+                                }
+                            }
+
+                            //call cancel on the correct list, so KO can take care of DOM manipulation
+                            if (sourceParent) {
+                                $(sourceParent === targetParent ? this : ui.sender || this).sortable("cancel");
+                            }
+                            //for a draggable item just remove the element
+                            else {
+                                $(el).remove();
+                            }
+
+                            //if beforeMove told us to cancel, then we are done
+                            if (arg && arg.cancelDrop) {
+                                return;
+                            }
+
+                            //if the strategy option is unset or false, employ the order strategy involving removal and insertion of items
+                            if (!sortable.hasOwnProperty("strategyMove") || sortable.strategyMove === false) {
+                                //do the actual move
+                                if (targetIndex >= 0) {
+                                    if (sourceParent) {
+                                        sourceParent.splice(sourceIndex, 1);
+
+                                        //if using deferred updates plugin, force updates
+                                        if (ko.processAllDeferredBindingUpdates) {
+                                            ko.processAllDeferredBindingUpdates();
+                                        }
+
+                                        //if using deferred updates on knockout 3.4, force updates
+                                        if (ko.options && ko.options.deferUpdates) {
+                                            ko.tasks.runEarly();
+                                        }
+                                    }
+
+                                    targetParent.splice(targetIndex, 0, item);
+                                }
+
+                                //rendering is handled by manipulating the observableArray; ignore dropped element
+                                dataSet(el, ITEMKEY, null);
+                            }
+                            else { //employ the strategy of moving items
+                                if (targetIndex >= 0) {
+                                    if (sourceParent) {
+                                        if (sourceParent !== targetParent) {
+                                            // moving from one list to another
+
+                                            sourceParent.splice(sourceIndex, 1);
+                                            targetParent.splice(targetIndex, 0, item);
+
+                                            //rendering is handled by manipulating the observableArray; ignore dropped element
+                                            dataSet(el, ITEMKEY, null);
+                                            ui.item.remove();
+                                        }
+                                        else {
+                                            // moving within same list
+                                            var underlyingList = unwrap(sourceParent);
+
+                                            // notify 'beforeChange' subscribers
+                                            if (sourceParent.valueWillMutate) {
+                                                sourceParent.valueWillMutate();
+                                            }
+
+                                            // move from source index ...
+                                            underlyingList.splice(sourceIndex, 1);
+                                            // ... to target index
+                                            underlyingList.splice(targetIndex, 0, item);
+
+                                            // notify subscribers
+                                            if (sourceParent.valueHasMutated) {
+                                                sourceParent.valueHasMutated();
+                                            }
+                                        }
+                                    }
+                                    else {
+                                        // drop new element from outside
+                                        targetParent.splice(targetIndex, 0, item);
+
+                                        //rendering is handled by manipulating the observableArray; ignore dropped element
+                                        dataSet(el, ITEMKEY, null);
+                                        ui.item.remove();
+                                    }
+                                }
+                            }
+
+                            //if using deferred updates plugin, force updates
+                            if (ko.processAllDeferredBindingUpdates) {
+                                ko.processAllDeferredBindingUpdates();
+                            }
+
+                            //allow binding to accept a function to execute after moving the item
+                            if (sortable.afterMove) {
+                                sortable.afterMove.call(this, arg, event, ui);
+                            }
+                        }
+
+                        if (updateActual) {
+                            updateActual.apply(this, arguments);
+                        }
+                    },
+                    connectWith: sortable.connectClass ? "." + sortable.connectClass : false
+                }));
+
+                //handle enabling/disabling sorting
+                if (sortable.isEnabled !== undefined) {
+                    ko.computed({
+                        read: function() {
+                            $element.sortable(unwrap(sortable.isEnabled) ? "enable" : "disable");
+                        },
+                        disposeWhenNodeIsRemoved: element
+                    });
+                }
+            }, 0);
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                //only call destroy if sortable has been created
+                if ($element.data("ui-sortable") || $element.data("sortable")) {
+                    $element.sortable("destroy");
+                }
+
+                ko.utils.toggleDomNodeCssClass(element, sortable.connectClass, false);
+
+                //do not create the sortable if the element has been removed from DOM
+                clearTimeout(createTimeout);
+            });
+
+            return { 'controlsDescendantBindings': true };
+        },
+        update: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var templateOptions = prepareTemplateOptions(valueAccessor, "foreach");
+
+            //attach meta-data
+            dataSet(element, LISTKEY, templateOptions.foreach);
+
+            //call template binding's update with correct options
+            ko.bindingHandlers.template.update(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        connectClass: 'ko_container',
+        allowDrop: true,
+        afterMove: null,
+        beforeMove: null,
+        options: {}
+    };
+
+    //create a draggable that is appropriate for dropping into a sortable
+    ko.bindingHandlers.draggable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var value = unwrap(valueAccessor()) || {},
+                options = value.options || {},
+                draggableOptions = ko.utils.extend({}, ko.bindingHandlers.draggable.options),
+                templateOptions = prepareTemplateOptions(valueAccessor, "data"),
+                connectClass = value.connectClass || ko.bindingHandlers.draggable.connectClass,
+                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.draggable.isEnabled;
+
+            value = "data" in value ? value.data : value;
+
+            //set meta-data
+            dataSet(element, DRAGKEY, value);
+
+            //override global options with override options passed in
+            ko.utils.extend(draggableOptions, options);
+
+            //setup connection to a sortable
+            draggableOptions.connectToSortable = connectClass ? "." + connectClass : false;
+
+            //initialize draggable
+            $(element).draggable(draggableOptions);
+
+            //handle enabling/disabling sorting
+            if (isEnabled !== undefined) {
+                ko.computed({
+                    read: function() {
+                        $(element).draggable(unwrap(isEnabled) ? "enable" : "disable");
+                    },
+                    disposeWhenNodeIsRemoved: element
+                });
+            }
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                $(element).draggable("destroy");
+            });
+
+            return ko.bindingHandlers.template.init(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        update: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var templateOptions = prepareTemplateOptions(valueAccessor, "data");
+
+            return ko.bindingHandlers.template.update(element, function() { return templateOptions; }, allBindingsAccessor, data, context);
+        },
+        connectClass: ko.bindingHandlers.sortable.connectClass,
+        options: {
+            helper: "clone"
+        }
+    };
+
+    // Simple Droppable Implementation
+    // binding that updates (function or observable)
+    ko.bindingHandlers.droppable = {
+        init: function(element, valueAccessor, allBindingsAccessor, data, context) {
+            var value = unwrap(valueAccessor()) || {},
+                options = value.options || {},
+                droppableOptions = ko.utils.extend({}, ko.bindingHandlers.droppable.options),
+                isEnabled = value.isEnabled !== undefined ? value.isEnabled : ko.bindingHandlers.droppable.isEnabled;
+
+            //override global options with override options passed in
+            ko.utils.extend(droppableOptions, options);
+
+            //get reference to drop method
+            value = "data" in value ? value.data : valueAccessor();
+
+            //set drop method
+            droppableOptions.drop = function(event, ui) {
+                var droppedItem = dataGet(ui.draggable[0], DRAGKEY) || dataGet(ui.draggable[0], ITEMKEY);
+                value(droppedItem);
+            };
+
+            //initialize droppable
+            $(element).droppable(droppableOptions);
+
+            //handle enabling/disabling droppable
+            if (isEnabled !== undefined) {
+                ko.computed({
+                    read: function() {
+                        $(element).droppable(unwrap(isEnabled) ? "enable": "disable");
+                    },
+                    disposeWhenNodeIsRemoved: element
+                });
+            }
+
+            //handle disposal
+            ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
+                $(element).droppable("destroy");
+            });
+        },
+        options: {
+            accept: "*"
+        }
+    };
+});

--- a/octoprint_consolidate_temp_control/templates/consolidate_temp_control_settings.jinja2
+++ b/octoprint_consolidate_temp_control/templates/consolidate_temp_control_settings.jinja2
@@ -9,16 +9,20 @@
 	</div>
 	<div class="row-fluid"><h5><u>{{ _('Layout') }}</u></h5></div>
 	<div class="row-fluid">
-		<div class="span4">
+		<div class="span4" title="{{ _('How the consolidated tabs are placed.') }}">
 			<select data-bind="value: settings.settings.plugins.consolidate_temp_control.layout">
 				<option value="horizontal">Horizontal</option>
 				<option value="vertical">Vertical</option>
 			</select>
 		</div>
-		<div class="span4" style="padding-top: 3px;" data-bind="visible: settings.settings.plugins.consolidate_temp_control.layout() == 'horizontal'">
+		<div class="span3" style="padding-top: 3px;" title="{{ _('Make navbar full width of browser.') }}" data-bind="visible: settings.settings.plugins.consolidate_temp_control.layout() == 'horizontal'">
 			<label class="checkbox">
-			<input type="checkbox" data-bind="checked: settings.settings.plugins.consolidate_temp_control.resize_navbar" /> {{ _('Resize Navbar') }}
+			    <input type="checkbox" data-bind="checked: settings.settings.plugins.consolidate_temp_control.resize_navbar" /> {{ _('Resize Navbar') }}
 			</label>
+		</div>
+		<div class="span5 input-prepend" title="{{ _('When window size is smaller than this threshold vertical mode will be enforced, enter 0 to always use horizontal mode.') }}" data-bind="visible: settings.settings.plugins.consolidate_temp_control.layout() == 'horizontal'">
+            <label class="input add-on">{{ _('Resolution Threshold') }}</label>
+            <input class="input-mini" type="number" min="0" data-bind="value: settings.settings.plugins.consolidate_temp_control.resolution_threshold" />
 		</div>
 	</div>
 </form>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_consolidate_temp_control"
 plugin_name = "Consolidate Temp Control"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.8"
+plugin_version = "0.1.8rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_consolidate_temp_control"
 plugin_name = "Consolidate Temp Control"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.8rc1"
+plugin_version = "0.1.8"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_consolidate_temp_control"
 plugin_name = "Consolidate Temp Control"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.8rc2"
+plugin_version = "0.1.8"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_consolidate_temp_control"
 plugin_name = "Consolidate Temp Control"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.7"
+plugin_version = "0.1.8rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
**Added**

* resolution threshold option for horizontal mode to switch to vertical mode automatically
* release channels for OctoPrint 1.5.0+ for future rc testing, similar to OctoPrint as described [here](https://community.octoprint.org/t/how-to-use-the-release-channels-to-help-test-release-candidates/402)

**Updated**

* knockout sortable library for OctoPrint 1.5.0 compatibility

**Fixed**

* conflicts with Themeify and DragonOrder